### PR TITLE
Prefectures APIを呼び出す場所を変える

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -20,7 +20,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache node_modules 📦
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,20 @@
 import styles from '@/styles/page.module.scss';
 import { Contaier } from '@/components/Container';
+import { BASE_URL } from '@/env';
+import { throwError } from '@/lib/throwError';
+import type { GetPrefecturesResponse } from '@/interfaces/prefectures';
 
-export default function Home() {
-  return (
-    <main className={styles.main}>
-      <Contaier />
-    </main>
-  );
+export default async function Home() {
+  try {
+    const res = await fetch(`${BASE_URL}/api/prefectures`);
+    const data = (await res.json()) as GetPrefecturesResponse;
+
+    return (
+      <main className={styles.main}>
+        <Contaier PrefecturesData={data} />
+      </main>
+    );
+  } catch (e) {
+    throwError(e);
+  }
 }

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -1,10 +1,16 @@
+'use client';
 import { Graph } from './Graph';
 import { Selector } from './Selector';
+import type { GetPrefecturesResponse } from '@/interfaces/prefectures';
 
-export const Contaier = () => {
+interface Props {
+  PrefecturesData: GetPrefecturesResponse;
+}
+
+export const Contaier = ({ PrefecturesData }: Props) => {
   return (
     <>
-      <Selector />
+      <Selector PrefecturesData={PrefecturesData} />
       <Graph />
     </>
   );

--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -1,25 +1,20 @@
-import { BASE_URL } from '@/env';
-import { throwError } from '@/lib/throwError';
 import type { GetPrefecturesResponse } from '@/interfaces/prefectures';
 
-export const Selector = async () => {
-  try {
-    const res = await fetch(`${BASE_URL}/api/prefectures`);
-    const data = (await res.json()) as GetPrefecturesResponse;
+interface Props {
+  PrefecturesData: GetPrefecturesResponse;
+}
 
-    return (
-      <>
-        {data.result.map((item) => {
-          return (
-            <label key={item.prefCode}>
-              <input type="checkbox" value={item.prefCode} />
-              {item.prefName}
-            </label>
-          );
-        })}
-      </>
-    );
-  } catch (e) {
-    throwError(e);
-  }
+export const Selector = ({ PrefecturesData }: Props) => {
+  return (
+    <>
+      {PrefecturesData.result.map((item) => {
+        return (
+          <label key={item.prefCode}>
+            <input type="checkbox" value={item.prefCode} />
+            {item.prefName}
+          </label>
+        );
+      })}
+    </>
+  );
 };


### PR DESCRIPTION
# Pull Request

## Issue 番号

- #33 

## 修正内容

- prefecturesをpage.tsxで呼ぶようにする
  - こうすることでContainer.tsxでuseEffectなど値を管理するものが使用可能になる
- Actionsのactions/cacheのバージョンが古かったので3に上げた
