### PR TITLE
ラジオボタンで表示切り替え

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -1,17 +1,34 @@
 'use client';
 import { Graph } from './Graph';
 import { Selector } from './Selector';
-import type { GetPrefecturesResponse } from '@/interfaces/prefectures';
+import { useCallback, useState } from 'react';
+import type { MouseEventHandler } from 'react';
+import type {
+  DisplayConditions,
+  GetPrefecturesResponse,
+} from '@/interfaces/prefectures';
 
 interface Props {
   PrefecturesData: GetPrefecturesResponse;
 }
 
 export const Contaier = ({ PrefecturesData }: Props) => {
+  const [displayCondition, setDisplayCondition] =
+    useState<DisplayConditions>('総人口');
+
+  const changeDisplayCondition: MouseEventHandler<HTMLInputElement> =
+    useCallback((e) => {
+      setDisplayCondition(e.currentTarget.value as DisplayConditions);
+    }, []);
+
   return (
     <>
-      <Selector PrefecturesData={PrefecturesData} />
-      <Graph />
+      <Selector
+        PrefecturesData={PrefecturesData}
+        displayCondition={displayCondition}
+        changeDisplayCondition={changeDisplayCondition}
+      />
+      <Graph displayCondition={displayCondition} />
     </>
   );
 };

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -5,8 +5,13 @@ import Highcharts from 'highcharts';
 import HighchartsExporting from 'highcharts/modules/exporting';
 import HighchartsReact from 'highcharts-react-official';
 import { useEffect, useMemo } from 'react';
+import type { DisplayConditions } from '@/interfaces/prefectures';
 
-export const Graph = () => {
+interface Props {
+  displayCondition: DisplayConditions;
+}
+
+export const Graph = ({ displayCondition }: Props) => {
   const { populationData, mutatePopulation, isLoading } = usePopulation({
     prefCode: 11,
   });
@@ -20,7 +25,9 @@ export const Graph = () => {
   }, [mutatePopulation]);
 
   const options = useMemo(() => {
-    const list = populationData?.result.data[0];
+    const list = populationData?.result.data.filter(
+      (data) => data.label === displayCondition,
+    )[0];
     const year = list?.data.map((item) => item.year);
     const value = list?.data.map((item) => item.value);
 
@@ -45,7 +52,7 @@ export const Graph = () => {
         },
       ],
     };
-  }, [populationData]);
+  }, [displayCondition, populationData]);
 
   if (isLoading) return <></>;
 

--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -1,20 +1,49 @@
-import type { GetPrefecturesResponse } from '@/interfaces/prefectures';
+import {
+  DisplayConditionsList,
+  type DisplayConditions,
+  type GetPrefecturesResponse,
+} from '@/interfaces/prefectures';
+import type { MouseEventHandler } from 'react';
 
 interface Props {
   PrefecturesData: GetPrefecturesResponse;
+  displayCondition: DisplayConditions;
+  changeDisplayCondition: MouseEventHandler<HTMLInputElement>;
 }
 
-export const Selector = ({ PrefecturesData }: Props) => {
+export const Selector = ({
+  PrefecturesData,
+  displayCondition,
+  changeDisplayCondition,
+}: Props) => {
   return (
     <>
-      {PrefecturesData.result.map((item) => {
-        return (
-          <label key={item.prefCode}>
-            <input type="checkbox" value={item.prefCode} />
-            {item.prefName}
-          </label>
-        );
-      })}
+      <div>
+        {PrefecturesData.result.map((item) => {
+          return (
+            <label key={item.prefCode}>
+              <input type="checkbox" value={item.prefCode} />
+              {item.prefName}
+            </label>
+          );
+        })}
+      </div>
+      <div>
+        {Object.values(DisplayConditionsList).map((value) => {
+          return (
+            <label key={value}>
+              <input
+                type="radio"
+                name="display_conditions"
+                value={value}
+                onClick={changeDisplayCondition}
+                defaultChecked={displayCondition === value}
+              />
+              {value}
+            </label>
+          );
+        })}
+      </div>
     </>
   );
 };

--- a/src/interfaces/prefectures.ts
+++ b/src/interfaces/prefectures.ts
@@ -7,3 +7,13 @@ export interface GetPrefecturesResponse {
     },
   ];
 }
+
+export const DisplayConditionsList = {
+  総人口: '総人口',
+  年少人口: '年少人口',
+  生産年齢人口: '生産年齢人口',
+  老年人口: '老年人口',
+} as const;
+
+export type DisplayConditions =
+  (typeof DisplayConditionsList)[keyof typeof DisplayConditionsList];


### PR DESCRIPTION
# Pull Request

## Issue 番号

- #34 

## 修正内容

- ラジオボタンで「総人口」「年少人口」「生産年齢人口」「老年人口」を切り替える機能の実装
