### PR TITLE
checkboxの状態でデータがフィルタリングされるようにする

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -16,15 +16,26 @@ interface Props {
 export const Contaier = ({ PrefecturesData }: Props) => {
   const [currentPrefectures, setCurrentPrefectures] =
     useState<PrefecturesList>();
+  const [checkedPrefectures, setCheckedPrefectures] = useState<string[]>([]);
   const [displayCondition, setDisplayCondition] =
     useState<DisplayConditions>('総人口');
 
   const changePrefectures: MouseEventHandler<HTMLInputElement> = useCallback(
     (e) => {
-      if (!e.currentTarget.checked) return;
+      const currentValue = e.currentTarget.value;
+      if (!e.currentTarget.checked) {
+        setCheckedPrefectures((prev) =>
+          prev.filter((item) => !item.includes(currentValue)),
+        );
+        return;
+      }
+      setCheckedPrefectures((prev) => {
+        const currentArray = [...prev, currentValue];
+        return [...new Set(currentArray)];
+      });
       setCurrentPrefectures({
         prefCode: Number(e.currentTarget.id),
-        prefName: e.currentTarget.value,
+        prefName: currentValue,
       });
     },
     [],
@@ -45,6 +56,7 @@ export const Contaier = ({ PrefecturesData }: Props) => {
       />
       {currentPrefectures !== undefined && (
         <Graph
+          checkedPrefectures={checkedPrefectures}
           displayCondition={displayCondition}
           currentPrefectures={currentPrefectures}
         />

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -11,14 +11,14 @@ import type {
 } from '@/interfaces/prefectures';
 import type { PopulationGraphData } from '@/interfaces/population';
 
+if (typeof Highcharts === 'object') {
+  HighchartsExporting(Highcharts);
+}
+
 interface Props {
   checkedPrefectures: string[];
   displayCondition: DisplayConditions;
   currentPrefectures: PrefecturesList;
-}
-
-if (typeof Highcharts === 'object') {
-  HighchartsExporting(Highcharts);
 }
 
 export const Graph = ({

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -12,6 +12,7 @@ import type {
 import type { PopulationGraphData } from '@/interfaces/population';
 
 interface Props {
+  checkedPrefectures: string[];
   displayCondition: DisplayConditions;
   currentPrefectures: PrefecturesList;
 }
@@ -20,12 +21,20 @@ if (typeof Highcharts === 'object') {
   HighchartsExporting(Highcharts);
 }
 
-export const Graph = ({ displayCondition, currentPrefectures }: Props) => {
+export const Graph = ({
+  checkedPrefectures,
+  displayCondition,
+  currentPrefectures,
+}: Props) => {
   const [graphData, setGraphData] = useState<PopulationGraphData[]>();
   const { populationData } = usePopulation({
     prefCode: currentPrefectures.prefCode,
   });
-  const { options } = useHighcharts({ displayCondition, graphData });
+  const { options } = useHighcharts({
+    checkedPrefectures,
+    displayCondition,
+    graphData,
+  });
 
   useEffect(() => {
     if (!populationData) return;

--- a/src/hooks/useHighcharts.ts
+++ b/src/hooks/useHighcharts.ts
@@ -12,11 +12,6 @@ const DEFAULT_OPTIONS = {
   title: {
     text: 'グラフ',
   },
-  xAxis: {
-    title: {
-      text: '年度',
-    },
-  },
   series: [],
 };
 
@@ -59,9 +54,7 @@ export const useHighcharts = ({
     });
 
     return {
-      title: {
-        text: 'グラフ',
-      },
+      ...DEFAULT_OPTIONS,
       xAxis: {
         title: {
           text: '年度',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "downlevelIteration": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
# Pull Request

## Issue 番号

- #43 

## 修正内容

- チェックボックスがtrueの場合はグラフに表示、falseの場合は非表示になるようにした
- Set関数を使えるようにするためtsconfigに `"downlevelIteration": true` を追加