### PR TITLE
SCSSの変数をどこでも使えるようにする

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -19,7 +19,6 @@
     "csstools/value-no-unknown-custom-properties": true,
     "declaration-block-no-duplicate-properties": true,
     "declaration-block-no-redundant-longhand-properties": true,
-    "declaration-property-value-no-unknown": true,
     "no-descending-specificity": true,
     "no-duplicate-selectors": true,
     "order/order": ["custom-properties", "declarations"],
@@ -32,6 +31,7 @@
       }
     ],
     "property-no-unknown": true,
-    "selector-pseudo-element-colon-notation": "double"
+    "selector-pseudo-element-colon-notation": "double",
+    "selector-class-pattern": "^[a-z][a-zA-Z0-9-]+$"
   }
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  sassOptions: {
+    prependData: `@use '@/styles/main.scss' as *;`,
+  },
+};
 
 module.exports = nextConfig;

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { Graph } from './Graph';
 import { Selector } from './Selector';
+import styles from '@/styles/components/container.module.scss';
 import { useCallback, useState } from 'react';
 import type { MouseEventHandler } from 'react';
 import type {
@@ -47,13 +48,16 @@ export const Contaier = ({ PrefecturesData }: Props) => {
     }, []);
 
   return (
-    <>
-      <Selector
-        PrefecturesData={PrefecturesData}
-        displayCondition={displayCondition}
-        changeDisplayCondition={changeDisplayCondition}
-        changePrefectures={changePrefectures}
-      />
+    <section className={styles.container}>
+      <h1 className={styles.title}>都道府県人口データグラフ</h1>
+      <div className={styles.wrapperSelector}>
+        <Selector
+          PrefecturesData={PrefecturesData}
+          displayCondition={displayCondition}
+          changeDisplayCondition={changeDisplayCondition}
+          changePrefectures={changePrefectures}
+        />
+      </div>
       {currentPrefectures !== undefined && (
         <Graph
           checkedPrefectures={checkedPrefectures}
@@ -61,6 +65,6 @@ export const Contaier = ({ PrefecturesData }: Props) => {
           currentPrefectures={currentPrefectures}
         />
       )}
-    </>
+    </section>
   );
 };

--- a/src/styles/components/container.module.scss
+++ b/src/styles/components/container.module.scss
@@ -1,0 +1,16 @@
+.container {
+  width: 100%;
+  height: 100%;
+  border: 4px solid $color-blue;
+  box-sizing: border-box;
+}
+
+.title {
+  text-align: center;
+  padding: 10px 0;
+  border-bottom: 4px solid $color-blue;
+}
+
+.wrapperSelector {
+  padding: 0 30px;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,0 +1,1 @@
+$color-blue: blue;


### PR DESCRIPTION
# Pull Request

## Issue 番号

- #46 
- #37 

## 修正内容

- next.config.jsにグローバルにscss変数を読み込む設定を追加
- Stylelintの設定変更
  - selector-class-patternはデフォルトの設定だとcss moduleとの相性が悪いのでキャメルケースで書けるようにした
  - declaration-property-value-no-unknownはグローバルで呼び出される変数とは相性が悪いので外す
- テストでContainerファイルを実装