### PR TITLE
人口構成APIのエラー処理を入れる

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,9 @@ const customJestConfig = {
     '^@/(.*)$': '<rootDir>/$1',
   },
   testEnvironment: 'jest-environment-jsdom',
+  globals: {
+    fetch,
+  },
 };
 
 module.exports = createJestConfig(customJestConfig);

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -15,9 +15,11 @@ export const Container = ({ prefecturesData }: Props) => {
     currentPrefectures,
     displayCondition,
     graphData,
+    isLoading,
     changePrefectures,
     changeDisplayCondition,
     setGraphData,
+    setIsLoading,
   } = useDataSelector();
 
   return (
@@ -30,6 +32,7 @@ export const Container = ({ prefecturesData }: Props) => {
           changeDisplayCondition={changeDisplayCondition}
           changePrefectures={changePrefectures}
         />
+        {isLoading && <div className={styles.cover} />}
       </div>
       {currentPrefectures !== undefined && (
         <Graph
@@ -37,6 +40,7 @@ export const Container = ({ prefecturesData }: Props) => {
           currentPrefectures={currentPrefectures}
           graphData={graphData}
           setGraphData={setGraphData}
+          setIsLoading={setIsLoading}
         />
       )}
     </section>

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -2,7 +2,6 @@
 import { usePopulation } from '@/hooks/api/usePopulation';
 import { useHighcharts } from '@/hooks/useHighcharts';
 import Highcharts from 'highcharts';
-import HighchartsExporting from 'highcharts/modules/exporting';
 import HighchartsAccessibility from 'highcharts/modules/accessibility';
 import HighchartsReact from 'highcharts-react-official';
 import { type Dispatch, type SetStateAction, useEffect } from 'react';
@@ -13,7 +12,6 @@ import type {
 import type { PopulationGraphData } from '@/interfaces/population';
 
 if (typeof Highcharts === 'object') {
-  HighchartsExporting(Highcharts);
   HighchartsAccessibility(Highcharts);
 }
 

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -3,6 +3,7 @@ import { usePopulation } from '@/hooks/api/usePopulation';
 import { useHighcharts } from '@/hooks/useHighcharts';
 import Highcharts from 'highcharts';
 import HighchartsExporting from 'highcharts/modules/exporting';
+import HighchartsAccessibility from 'highcharts/modules/accessibility';
 import HighchartsReact from 'highcharts-react-official';
 import { type Dispatch, type SetStateAction, useEffect } from 'react';
 import type {
@@ -13,6 +14,7 @@ import type { PopulationGraphData } from '@/interfaces/population';
 
 if (typeof Highcharts === 'object') {
   HighchartsExporting(Highcharts);
+  HighchartsAccessibility(Highcharts);
 }
 
 interface Props {

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -20,6 +20,7 @@ interface Props {
   currentPrefectures: PrefecturesList;
   graphData: PopulationGraphData[] | undefined;
   setGraphData: Dispatch<SetStateAction<PopulationGraphData[] | undefined>>;
+  setIsLoading: Dispatch<SetStateAction<boolean>>;
 }
 
 export const Graph = ({
@@ -27,14 +28,17 @@ export const Graph = ({
   currentPrefectures,
   graphData,
   setGraphData,
+  setIsLoading,
 }: Props) => {
-  const { populationData } = usePopulation({
+  const { populationData, isLoading } = usePopulation({
     prefCode: currentPrefectures.prefCode,
   });
   const { options } = useHighcharts({
     displayCondition,
     graphData,
   });
+
+  useEffect(() => setIsLoading(isLoading), [isLoading, setIsLoading]);
 
   useEffect(() => {
     if (!populationData) return;

--- a/src/hooks/api/usePopulation.ts
+++ b/src/hooks/api/usePopulation.ts
@@ -11,10 +11,10 @@ export const usePopulation = ({ prefCode }: Props) => {
     prefCode: prefCode?.toString() || '',
   }).toString();
 
-  const { data } = useSWR<{ data: GetPopulationResponse }>(
+  const { data, isLoading } = useSWR<{ data: GetPopulationResponse }>(
     prefCode ? `/population/composition/perYear?${urlSearchParam}` : null,
     fetcher,
   );
 
-  return { populationData: data?.data };
+  return { populationData: data?.data, isLoading };
 };

--- a/src/hooks/api/usePopulation.ts
+++ b/src/hooks/api/usePopulation.ts
@@ -1,4 +1,5 @@
 import { fetcher } from './fetcher';
+import { throwError } from '@/lib/throwError';
 import useSWR from 'swr';
 import type { GetPopulationResponse } from '@/interfaces/population';
 
@@ -11,10 +12,19 @@ export const usePopulation = ({ prefCode }: Props) => {
     prefCode: prefCode?.toString() || '',
   }).toString();
 
-  const { data, isLoading } = useSWR<{ data: GetPopulationResponse }>(
+  const { data, isLoading, error } = useSWR<
+    {
+      data: GetPopulationResponse;
+    },
+    Error
+  >(
     prefCode ? `/population/composition/perYear?${urlSearchParam}` : null,
     fetcher,
   );
+
+  if (error) {
+    throwError(error);
+  }
 
   return { populationData: data?.data, isLoading };
 };

--- a/src/hooks/useDataSelector.ts
+++ b/src/hooks/useDataSelector.ts
@@ -13,6 +13,7 @@ export const useDataSelector = () => {
     DisplayConditionsList['総人口'],
   );
   const [graphData, setGraphData] = useState<PopulationGraphData[]>();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const changePrefectures: MouseEventHandler<HTMLInputElement> = useCallback(
     (e) => {
@@ -41,8 +42,10 @@ export const useDataSelector = () => {
     currentPrefectures,
     displayCondition,
     graphData,
+    isLoading,
     changePrefectures,
     changeDisplayCondition,
     setGraphData,
+    setIsLoading,
   };
 };

--- a/src/hooks/useHighcharts.ts
+++ b/src/hooks/useHighcharts.ts
@@ -14,9 +14,6 @@ export const useHighcharts = ({ displayCondition, graphData }: Props) => {
         text: `${displayCondition}グラフ`,
       },
       series: [],
-      accessibility: {
-        enabled: false,
-      },
     };
   }, [displayCondition]);
 

--- a/src/hooks/useHighcharts.ts
+++ b/src/hooks/useHighcharts.ts
@@ -14,6 +14,9 @@ export const useHighcharts = ({ displayCondition, graphData }: Props) => {
         text: `${displayCondition}グラフ`,
       },
       series: [],
+      accessibility: {
+        enabled: false,
+      },
     };
   }, [displayCondition]);
 

--- a/src/styles/components/container.module.scss
+++ b/src/styles/components/container.module.scss
@@ -13,5 +13,16 @@
 }
 
 .wrapperSelector {
+  position: relative;
   padding: 0 30px;
+}
+
+.cover {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba($color-white, 0.7);
+  backdrop-filter: blur(2px);
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,5 +1,6 @@
 $color-blue: blue;
 $color-black: black;
+$color-white: white;
 
 @mixin sp {
   @media (width <= 767px) {

--- a/src/test/container.test.tsx
+++ b/src/test/container.test.tsx
@@ -26,9 +26,10 @@ describe('containerのテスト', () => {
 
     await userEvent.click(hokkaido);
 
-    const element = screen.queryByText(
-      `${DisplayConditionsList['総人口']}グラフ`,
-    );
+    const element = screen.getByRole('heading', {
+      level: 2,
+      name: `${DisplayConditionsList['総人口']}グラフ`,
+    });
 
     expect(element).toBeInTheDocument();
   });


### PR DESCRIPTION
# Pull Request

## Issue 番号

- #70 

## 修正内容

- 人口構成APIでエラーがあった場合はエラーを投げるようにした
- 人口構成API通信中は新たにチェックボックスが押せないように白い透明なカバーを表示させる
- Highchartsの設定を変更
- テストが落ちるようになったので条件をより詳細に指定